### PR TITLE
Remove creationTimestamp from configmap manifest

### DIFF
--- a/deployment/configmap.yaml
+++ b/deployment/configmap.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2019-10-30T21:56:10Z"
   name: kube-diff-logger
   namespace: default
 data:


### PR DESCRIPTION
this property gets added by k8s so it should be in the configmap manifest.