### PR TITLE
Remove cronjob

### DIFF
--- a/deployment/configmap.yaml
+++ b/deployment/configmap.yaml
@@ -12,5 +12,3 @@ data:
       type: "statefulset"
     - nameFilter: "*"
       type: "daemonset"
-    - nameFilter: "*"
-      type: "cronjob"


### PR DESCRIPTION
It seems `cronjob` is no longer supported:

```
2021/07/26 16:01:30 informerForName failed: Unsupported informer name cronjob
```