### PR TITLE
Use updated CronJob API

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func informerForName(name string, i informers.SharedInformerFactory) (cache.Shar
 	case "daemonset":
 		return i.Apps().V1().DaemonSets().Informer(), wrapper.WrapDaemonSet, nil
 	case "cronjob":
-		return i.Batch().V1beta1().CronJobs().Informer(), wrapper.WrapCronJob, nil
+		return i.Batch().V1().CronJobs().Informer(), wrapper.WrapCronJob, nil
 	}
 
 	return nil, nil, fmt.Errorf("Unsupported informer name %s", name)


### PR DESCRIPTION
Use the new CronJob API version. Fixes...

```
W0606 07:06:02.402364       1 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```